### PR TITLE
Fix package installation by adding dynamic metadata fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,17 @@
 [project]
 name = "pyfolio-reloaded"
-version = "0.1.0"
 requires-python = '>=3.7'
+dynamic = [
+    "version",
+    "readme",
+    "license",
+    "authors",
+    "maintainers",
+    "classifiers",
+    "dependencies",
+    "optional-dependencies",
+    "description",
+]
 
 [build-system]
 requires = [


### PR DESCRIPTION
The pyproject.toml had a [project] table with static metadata, but all other metadata (readme, license, dependencies, etc.) was defined in setup.cfg. Newer setuptools requires metadata defined outside pyproject.toml to be explicitly listed as 'dynamic', otherwise it fails with an AttributeError when trying to process the readme field.